### PR TITLE
パフォーマンスチューニング

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,7 @@ const config = {
         'dist',
         'cdk.out',
         '.cdk.staging',
+        'bun.lockb',
     ],
     rules: {
         '@typescript-eslint/interface-name-prefix': 'off',

--- a/cdk/lib/base-stack.ts
+++ b/cdk/lib/base-stack.ts
@@ -230,9 +230,12 @@ export class SdtdBaseStack extends cdk.Stack {
                 '../../functions/package-lock.json',
             ),
             runtime: lambda.Runtime.NODEJS_18_X,
-            // NOTE: 128だと足りない
-            // aws-lambda-power-tuningでコスト最適と出た
-            memorySize: 256,
+            /**
+             * NOTE: 128MBだとメモリ不足
+             * 256MBだとメモリは足りているが、コールドスタート時にDiscordの初回応答の時間制限に間に合わないので512MB
+             * 256MBがaws-lambda-power-tuningでコスト最適と出た
+             */
+            memorySize: 512,
             timeout: cdk.Duration.seconds(300),
             environment: {
                 PREFIX: props.prefix,

--- a/cdk/lib/base-stack.ts
+++ b/cdk/lib/base-stack.ts
@@ -202,6 +202,7 @@ export class SdtdBaseStack extends cdk.Stack {
                 '../../functions/package-lock.json',
             ),
             runtime: lambda.Runtime.NODEJS_18_X,
+            // NOTE: aws-lambda-power-tuningでコスト最適と出た
             memorySize: 128,
             timeout: cdk.Duration.seconds(300),
             environment: {
@@ -229,7 +230,9 @@ export class SdtdBaseStack extends cdk.Stack {
                 '../../functions/package-lock.json',
             ),
             runtime: lambda.Runtime.NODEJS_18_X,
-            memorySize: 128,
+            // NOTE: 128だと足りない
+            // aws-lambda-power-tuningでコスト最適と出た
+            memorySize: 256,
             timeout: cdk.Duration.seconds(300),
             environment: {
                 PREFIX: props.prefix,

--- a/cdk/lib/base-stack.ts
+++ b/cdk/lib/base-stack.ts
@@ -1,3 +1,5 @@
+import path = require('path');
+
 import type { StackProps } from 'aws-cdk-lib';
 import * as cdk from 'aws-cdk-lib';
 import {
@@ -191,8 +193,14 @@ export class SdtdBaseStack extends cdk.Stack {
 
         // Lambda
         const commandFunc = new NodejsFunction(this, 'ServerCommand', {
-            entry: '../functions/handlers/server-command-handler/index.ts',
-            depsLockFilePath: '../functions/package-lock.json',
+            entry: path.join(
+                __dirname,
+                '../../functions/handlers/server-command-handler/index.ts',
+            ),
+            depsLockFilePath: path.join(
+                __dirname,
+                '../../functions/package-lock.json',
+            ),
             runtime: lambda.Runtime.NODEJS_18_X,
             memorySize: 128,
             timeout: cdk.Duration.seconds(300),
@@ -202,12 +210,24 @@ export class SdtdBaseStack extends cdk.Stack {
             },
             bundling: {
                 minify: true,
+                tsconfig: path.join(
+                    __dirname,
+                    '../../functions/tsconfig.build.json',
+                ),
+                // https://middy.js.org/docs/best-practices/bundling#bundlers
+                externalModules: [],
             },
         });
 
         const handler = new NodejsFunction(this, 'DiscordBot', {
-            entry: '../functions/handlers/discord-bot-handler/index.ts',
-            depsLockFilePath: '../functions/package-lock.json',
+            entry: path.join(
+                __dirname,
+                '../../functions/handlers/discord-bot-handler/index.ts',
+            ),
+            depsLockFilePath: path.join(
+                __dirname,
+                '../../functions/package-lock.json',
+            ),
             runtime: lambda.Runtime.NODEJS_18_X,
             memorySize: 128,
             timeout: cdk.Duration.seconds(300),
@@ -218,6 +238,12 @@ export class SdtdBaseStack extends cdk.Stack {
             },
             bundling: {
                 minify: true,
+                tsconfig: path.join(
+                    __dirname,
+                    '../../functions/tsconfig.build.json',
+                ),
+                // https://middy.js.org/docs/best-practices/bundling#bundlers
+                externalModules: [],
             },
         });
 

--- a/functions/tsconfig.build.json
+++ b/functions/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "inlineSourceMap": false,
+    "inlineSources": false
+  },
+  "exclude": ["**/test", "**/*.test.ts"]
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "**/test", "dist", "**/*test.ts"]
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,11 @@
       "@/*": ["./*"]
     }
   },
-  "exclude": ["node_modules", "cdk.out", "dist"]
+  "exclude": [
+    "**/node_modules",
+    "**/cdk.out",
+    "dist",
+    "bun.lockb",
+    ".cdk.staging"
+  ]
 }


### PR DESCRIPTION
## 変更点

### ✅ eslintの設定見直し
eslintの実行に10秒以上かかっていたので対処した。

### ✅ Lambda関数のビルドオプション変更
#7 への対処 ＆ [middyのベストプラクティス](https://middy.js.org/docs/best-practices/bundling/#bundlers)に則るため。
これにより、コールドスタート時のInit時間が0.3秒ほど減少する。

### ✅ Lambdaのメモリサイズ変更
#7 への対処として、メモリ数を増加＝CPU性能を増加させて実行時間の短縮を図った。
最適な容量は[aws-lambda-power-tuning](https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-east-1:451282441545:applications~aws-lambda-power-tuning)で検証して設定。

#### DiscordBot
![スクリーンショット 2023-10-03 174704](https://github.com/Ry0xi/7dtd/assets/78286855/6ed959d5-a0a4-423b-85a7-407f09745406)

📝 **コスト的には256MBがよいが、コールドスタート時にDiscordの制限時間に間に合わないので512GBにする**

#### ServerCommand
![スクリーンショット 2023-10-03 174714](https://github.com/Ry0xi/7dtd/assets/78286855/4330c71c-2013-417c-8211-3d75db9a4cbb)
