### PR TITLE
fix: メンテナンスモードの判定処理が間違っていたのを修正

### DIFF
--- a/files/scripts/down_cron.sh
+++ b/files/scripts/down_cron.sh
@@ -49,7 +49,7 @@ while :; do
 done
 
 # メンテナンスモードの時はサーバー停止しない
-[[ $(get_ssm_value maintenance ) ]] && exit 0
+[[ $(get_ssm_value maintenance == true) ]] && exit 0
 
 post_discord "🖥️🧟‍♂️接続人数が一定時間0人だったため、サーバー[${SERVERNAME}]を停止しました"
 


### PR DESCRIPTION
true文字列との比較を行っていなかったので、正常終了してつねに条件式がtrueになっていた。